### PR TITLE
Add dependency-light BharatFed backend service (analytics, lending, API, tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,28 +1,71 @@
 # BharatFed
 
-BharatFed is a platform for the federation of financial tools for India - where the expense analysis, financial advice and access to microcredit is simple and easy for the underbanked and undereducated India.
+BharatFed is a platform for turning Account Aggregator financial data into practical tools for:
 
-We intend to serve the credit needs of 400 million Indians and to become a key component in the financial data value chain.
+- personal finance analytics,
+- explainable cashflow forecasting, and
+- P2P/micro-credit workflows.
 
-We built a platform which will utilize the consent approved financial data of a user through a new regulatory framework(Account Aggregators) and provide personal finance management, expense forecasting, p2p lending and micro loans.
+The original repository contains legacy experiments for privacy-preserving ML, FIU integration, and loan processing. This codebase has now been extended with a lightweight, dependency-minimal backend service that makes the repo usable without requiring the old TensorFlow stack.
 
-Our secret sauce is our expertise in privacy preserving machine learning which generate insights into credit worthiness of a User.
+## What is now available
 
-Usage:
-1) Install the requirements in a conda environment using pip > requirements.txt
+### Modernized backend service
 
-2) The LSTM based model is trained in train_tfe_model.py: run - python train_tfe_model.py
+The repository now includes a standard-library HTTP API that exposes:
 
-3) The differential privacy based linear ml_model is trained in train_dp_model.py: python train_dp_model.py
+- `/health` for service status,
+- `/analytics/overview` for account summaries from the sample FIU payload,
+- `/analytics/forecast?days=30` for rule-based recurring cashflow projections,
+- `/profiles` and `/profiles/<user_id>` for borrower/lender profile access,
+- `/loans`, `/loans/requests`, and `/portfolio/summary` for lending operations, and
+- `POST /loans/requests` to register new loan requests safely in SQLite.
 
-4) Testing finvu aa is done in some of the other files
+Run it locally with:
 
-5) Testing the federated model averaging code: python federated_model_gen.py
+```bash
+python app.py
+```
 
-Sample data is present in the JSON files.
+Or customize paths/host/port:
 
-Happy Exploring!
+```bash
+python app.py --host 0.0.0.0 --port 8080 --sample-data data_response_bharatfed99@finvu_1yr.txt --database bharat_fed.db
+```
 
+## Repository structure
+
+- `bharatfed/analytics.py` – FIU payload parsing, analytics summaries, and forecast generation.
+- `bharatfed/lending.py` – SQLite-backed profile, loan request, and portfolio helpers.
+- `bharatfed/service.py` – application service layer used by the API.
+- `bharatfed/api.py` – dependency-light HTTP server.
+- `app.py` – local server entrypoint.
+- `tests/` – built-in `unittest` coverage for analytics, lending, and HTTP endpoints.
+
+## Legacy ML scripts
+
+The original ML and experimentation scripts are still present:
+
+1. `train_tfe_model.py`
+2. `train_dp_model.py`
+3. `federated_model_gen.py`
+4. `test_fiu_api.py`
+5. `test_1yr_data_req.py`
+
+These scripts rely on older dependencies listed in `requirements.txt`. The new backend layer is intentionally written using the Python standard library so it can be exercised immediately in constrained environments.
+
+## Running tests
+
+Use Python’s built-in unittest discovery:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+## Data sources
+
+- Sample FIU responses are included in `data_response.txt` and `data_response_bharatfed99@finvu_1yr.txt`.
+- Lending data is backed by the checked-in SQLite database `bharat_fed.db`.
 
 ## Modernization Task Plan
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,36 @@
+"""Run the BharatFed API locally."""
+
+from __future__ import annotations
+
+import argparse
+
+from bharatfed import BharatFedService, create_server
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the BharatFed API server.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=8000, type=int)
+    parser.add_argument(
+        "--sample-data",
+        default="data_response_bharatfed99@finvu_1yr.txt",
+        help="Path to a BharatFed FIU response file.",
+    )
+    parser.add_argument(
+        "--database",
+        default="bharat_fed.db",
+        help="Path to the BharatFed SQLite database.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    service = BharatFedService(sample_data_path=args.sample_data, database_path=args.database)
+    server = create_server(args.host, args.port, service)
+    print(f"BharatFed API listening on http://{args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/bharatfed/__init__.py
+++ b/bharatfed/__init__.py
@@ -1,0 +1,6 @@
+"""BharatFed modernized service package."""
+
+from .api import BharatFedAPIHandler, create_server
+from .service import BharatFedService
+
+__all__ = ["BharatFedAPIHandler", "BharatFedService", "create_server"]

--- a/bharatfed/analytics.py
+++ b/bharatfed/analytics.py
@@ -1,0 +1,195 @@
+"""Core analytics for BharatFed built on the sample FIU payload format."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+import json
+from statistics import mean
+from typing import Any, Iterable
+
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+@dataclass(frozen=True)
+class Transaction:
+    """Normalized transaction record."""
+
+    date: date
+    txn_type: str
+    category: str
+    amount: float
+    current_balance: float
+    narration: str
+
+    @property
+    def signed_amount(self) -> float:
+        return self.amount if self.txn_type == "CREDIT" else -self.amount
+
+
+def load_fiu_payload(path: str | Path) -> dict[str, Any]:
+    """Load one of the BharatFed sample FIU response files."""
+
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def extract_transactions(payload: dict[str, Any]) -> list[Transaction]:
+    """Convert BharatFed FIU payloads into normalized transactions."""
+
+    raw_transactions = payload["body"][0]["fiObjects"][0]["Transactions"]["Transaction"]
+    transactions: list[Transaction] = []
+    for item in raw_transactions:
+        transactions.append(
+            Transaction(
+                date=datetime.strptime(item["valueDate"], DATE_FORMAT).date(),
+                txn_type=item["type"],
+                category=item["narration"],
+                amount=float(item["amount"]),
+                current_balance=float(item["currentBalance"]),
+                narration=item["narration"],
+            )
+        )
+    return sorted(transactions, key=lambda txn: txn.date)
+
+
+def _aggregate_by_category(transactions: Iterable[Transaction], txn_type: str) -> list[dict[str, Any]]:
+    totals: dict[str, float] = defaultdict(float)
+    counts: Counter[str] = Counter()
+    for txn in transactions:
+        if txn.txn_type != txn_type:
+            continue
+        totals[txn.category] += txn.amount
+        counts[txn.category] += 1
+    return [
+        {
+            "category": category,
+            "total_amount": round(total_amount, 2),
+            "transactions": counts[category],
+        }
+        for category, total_amount in sorted(totals.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+
+def _find_recurring_transactions(transactions: Iterable[Transaction]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[Transaction]] = defaultdict(list)
+    for txn in transactions:
+        grouped[(txn.txn_type, txn.category)].append(txn)
+
+    recurring: list[dict[str, Any]] = []
+    for (txn_type, category), entries in grouped.items():
+        if len(entries) < 2:
+            continue
+        ordered = sorted(entries, key=lambda txn: txn.date)
+        intervals = [
+            (ordered[index].date - ordered[index - 1].date).days
+            for index in range(1, len(ordered))
+        ]
+        average_interval = mean(intervals)
+        if average_interval > 45:
+            continue
+        recurring.append(
+            {
+                "type": txn_type,
+                "category": category,
+                "average_amount": round(mean(txn.amount for txn in ordered), 2),
+                "average_interval_days": round(average_interval, 1),
+                "last_seen": ordered[-1].date.isoformat(),
+            }
+        )
+    return sorted(
+        recurring,
+        key=lambda item: (item["average_interval_days"], item["category"], item["type"]),
+    )
+
+
+def summarize_transactions(transactions: Iterable[Transaction]) -> dict[str, Any]:
+    """Create an overview suitable for dashboards and API responses."""
+
+    ordered = list(sorted(transactions, key=lambda txn: txn.date))
+    if not ordered:
+        return {
+            "transaction_count": 0,
+            "date_range": None,
+            "credits_total": 0.0,
+            "debits_total": 0.0,
+            "net_cashflow": 0.0,
+            "current_balance": 0.0,
+            "average_credit": 0.0,
+            "average_debit": 0.0,
+            "top_income_categories": [],
+            "top_expense_categories": [],
+            "recurring_transactions": [],
+        }
+
+    credits = [txn.amount for txn in ordered if txn.txn_type == "CREDIT"]
+    debits = [txn.amount for txn in ordered if txn.txn_type == "DEBIT"]
+    credits_total = round(sum(credits), 2)
+    debits_total = round(sum(debits), 2)
+
+    return {
+        "transaction_count": len(ordered),
+        "date_range": {
+            "start": ordered[0].date.isoformat(),
+            "end": ordered[-1].date.isoformat(),
+        },
+        "credits_total": credits_total,
+        "debits_total": debits_total,
+        "net_cashflow": round(credits_total - debits_total, 2),
+        "current_balance": round(ordered[-1].current_balance, 2),
+        "average_credit": round(mean(credits), 2) if credits else 0.0,
+        "average_debit": round(mean(debits), 2) if debits else 0.0,
+        "top_income_categories": _aggregate_by_category(ordered, "CREDIT")[:5],
+        "top_expense_categories": _aggregate_by_category(ordered, "DEBIT")[:5],
+        "recurring_transactions": _find_recurring_transactions(ordered)[:10],
+    }
+
+
+def forecast_cashflow(transactions: Iterable[Transaction], days: int = 30) -> dict[str, Any]:
+    """Produce a transparent rule-based cashflow forecast."""
+
+    ordered = list(sorted(transactions, key=lambda txn: txn.date))
+    if not ordered:
+        return {"days": days, "forecast": [], "projected_end_balance": 0.0}
+
+    recurring = _find_recurring_transactions(ordered)
+    if not recurring:
+        return {
+            "days": days,
+            "forecast": [],
+            "projected_end_balance": round(ordered[-1].current_balance, 2),
+        }
+
+    current_balance = ordered[-1].current_balance
+    last_date = ordered[-1].date
+    forecast: list[dict[str, Any]] = []
+
+    for recurring_item in recurring:
+        interval = max(1, int(round(recurring_item["average_interval_days"])))
+        avg_amount = float(recurring_item["average_amount"])
+        next_date = datetime.strptime(recurring_item["last_seen"], DATE_FORMAT).date() + timedelta(
+            days=interval
+        )
+        while next_date <= last_date + timedelta(days=days):
+            signed_amount = avg_amount if recurring_item["type"] == "CREDIT" else -avg_amount
+            current_balance += signed_amount
+            forecast.append(
+                {
+                    "date": next_date.isoformat(),
+                    "type": recurring_item["type"],
+                    "category": recurring_item["category"],
+                    "amount": round(avg_amount, 2),
+                    "projected_balance": round(current_balance, 2),
+                }
+            )
+            next_date += timedelta(days=interval)
+
+    forecast.sort(key=lambda item: (item["date"], item["type"], item["category"]))
+    return {
+        "days": days,
+        "forecast": forecast,
+        "projected_end_balance": round(current_balance, 2),
+    }

--- a/bharatfed/api.py
+++ b/bharatfed/api.py
@@ -1,0 +1,95 @@
+"""Dependency-light HTTP API for BharatFed."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from .service import BharatFedService
+
+
+class BharatFedAPIHandler(BaseHTTPRequestHandler):
+    """JSON API exposing the modernized BharatFed service."""
+
+    service: BharatFedService
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib method name
+        self._dispatch("GET")
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib method name
+        self._dispatch("POST")
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        return
+
+    def _dispatch(self, method: str) -> None:
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        try:
+            if method == "GET" and parsed.path == "/health":
+                self._send_json(HTTPStatus.OK, self.service.health())
+                return
+            if method == "GET" and parsed.path == "/analytics/overview":
+                self._send_json(HTTPStatus.OK, self.service.analytics_overview())
+                return
+            if method == "GET" and parsed.path == "/analytics/forecast":
+                days = int(query.get("days", ["30"])[0])
+                self._send_json(HTTPStatus.OK, self.service.analytics_forecast(days=days))
+                return
+            if method == "GET" and parsed.path == "/profiles":
+                self._send_json(HTTPStatus.OK, {"profiles": self.service.list_profiles()})
+                return
+            if method == "GET" and parsed.path.startswith("/profiles/"):
+                user_id = parsed.path.rsplit("/", 1)[-1]
+                profile = self.service.get_profile(user_id)
+                if not profile:
+                    self._send_json(HTTPStatus.NOT_FOUND, {"error": "profile not found"})
+                    return
+                self._send_json(HTTPStatus.OK, profile)
+                return
+            if method == "GET" and parsed.path == "/loans/requests":
+                status = query.get("status", [None])[0]
+                self._send_json(
+                    HTTPStatus.OK,
+                    {"loan_requests": self.service.list_loan_requests(status=status)},
+                )
+                return
+            if method == "GET" and parsed.path == "/loans":
+                self._send_json(HTTPStatus.OK, {"loans": self.service.list_loans()})
+                return
+            if method == "GET" and parsed.path == "/portfolio/summary":
+                self._send_json(HTTPStatus.OK, self.service.portfolio_summary())
+                return
+            if method == "POST" and parsed.path == "/loans/requests":
+                payload = self._read_json_body()
+                created = self.service.create_loan_request(payload)
+                self._send_json(HTTPStatus.CREATED, created)
+                return
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "route not found"})
+
+    def _read_json_body(self) -> dict[str, Any]:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(content_length) if content_length else b"{}"
+        return json.loads(raw_body.decode("utf-8"))
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, indent=2).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def create_server(host: str, port: int, service: BharatFedService) -> ThreadingHTTPServer:
+    """Create a configured ThreadingHTTPServer instance."""
+
+    handler_class = type("ConfiguredBharatFedHandler", (BharatFedAPIHandler,), {"service": service})
+    return ThreadingHTTPServer((host, port), handler_class)

--- a/bharatfed/lending.py
+++ b/bharatfed/lending.py
@@ -1,0 +1,161 @@
+"""SQLite-backed lending workflows for BharatFed."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+import math
+import secrets
+import sqlite3
+from typing import Any
+
+
+class LendingRepository:
+    """Small repository abstraction over the legacy SQLite database."""
+
+    def __init__(self, database_path: str) -> None:
+        self.database_path = database_path
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def list_profiles(self) -> list[dict[str, Any]]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT userid, first_name, last_name, Pan, phone, email, last_balance,
+                       last_txn_amt, credit_score, bill_income_ratio, profile_text,
+                       frugality_factor, fin_goals
+                FROM profiles
+                ORDER BY userid
+                """
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def get_profile(self, user_id: str) -> dict[str, Any] | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT userid, first_name, last_name, Pan, phone, email, last_balance,
+                       last_txn_amt, credit_score, bill_income_ratio, profile_text,
+                       frugality_factor, fin_goals
+                FROM profiles
+                WHERE userid = ?
+                """,
+                (user_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def list_loan_requests(self, status: str | None = None) -> list[dict[str, Any]]:
+        query = "SELECT * FROM loan_reqs"
+        parameters: tuple[Any, ...] = ()
+        if status:
+            query += " WHERE req_status = ?"
+            parameters = (status,)
+        query += " ORDER BY created_at DESC"
+        with self._connect() as connection:
+            rows = connection.execute(query, parameters).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_loans(self) -> list[dict[str, Any]]:
+        with self._connect() as connection:
+            rows = connection.execute("SELECT * FROM loans ORDER BY last_updated DESC").fetchall()
+        return [dict(row) for row in rows]
+
+    @staticmethod
+    def calculate_monthly_emi(principal: float, annual_interest_rate: float, months: int) -> float:
+        """Calculate EMI using the standard amortization formula."""
+
+        if principal <= 0:
+            raise ValueError("principal must be positive")
+        if months <= 0:
+            raise ValueError("months must be positive")
+        monthly_rate = annual_interest_rate / 12 / 100
+        if monthly_rate == 0:
+            return round(principal / months, 2)
+        emi = principal * monthly_rate * math.pow(1 + monthly_rate, months)
+        emi /= math.pow(1 + monthly_rate, months) - 1
+        return round(emi, 2)
+
+    def create_loan_request(
+        self,
+        *,
+        borrower_id: str,
+        lender_id: str,
+        loan_amount: float,
+        interest_rate: float,
+        loan_period_months: int,
+        text: str,
+    ) -> dict[str, Any]:
+        borrower = self.get_profile(borrower_id)
+        lender = self.get_profile(lender_id)
+        if not borrower:
+            raise ValueError(f"unknown borrower_id: {borrower_id}")
+        if not lender:
+            raise ValueError(f"unknown lender_id: {lender_id}")
+        if borrower_id == lender_id:
+            raise ValueError("borrower and lender must be different users")
+        if loan_amount <= 0:
+            raise ValueError("loan_amount must be positive")
+        if interest_rate < 0:
+            raise ValueError("interest_rate cannot be negative")
+        if loan_period_months <= 0:
+            raise ValueError("loan_period_months must be positive")
+
+        loan_req_id = secrets.token_urlsafe(12)
+        created_at = datetime.now(UTC).isoformat(timespec="seconds")
+        payload = (
+            loan_req_id,
+            created_at,
+            borrower_id,
+            float(loan_amount),
+            float(interest_rate),
+            int(loan_period_months),
+            text.strip(),
+            lender_id,
+            "PENDING",
+            None,
+            None,
+            None,
+        )
+
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO loan_reqs (
+                    loan_req_id, created_at, borrower_id, loan_amount, interest_rate,
+                    loan_period, req_text, lender_id, req_status, approved_at, txn_id, loan_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                payload,
+            )
+            connection.commit()
+
+        return {
+            "loan_req_id": loan_req_id,
+            "created_at": created_at,
+            "borrower_id": borrower_id,
+            "lender_id": lender_id,
+            "loan_amount": float(loan_amount),
+            "interest_rate": float(interest_rate),
+            "loan_period_months": int(loan_period_months),
+            "status": "PENDING",
+        }
+
+    def portfolio_summary(self) -> dict[str, Any]:
+        loans = self.list_loans()
+        requests = self.list_loan_requests()
+        pending_requests = [request for request in requests if request["req_status"] == "PENDING"]
+        approved_requests = [request for request in requests if request["req_status"] == "APPROVED"]
+        active_principal = round(sum(float(loan["next_principal"]) for loan in loans), 2) if loans else 0.0
+        next_due_date = min((loan["next_pay_date"] for loan in loans), default=None)
+        return {
+            "profiles": len(self.list_profiles()),
+            "loan_requests_total": len(requests),
+            "loan_requests_pending": len(pending_requests),
+            "loan_requests_approved": len(approved_requests),
+            "active_loans": len(loans),
+            "active_principal_outstanding": active_principal,
+            "next_due_date": next_due_date,
+        }

--- a/bharatfed/service.py
+++ b/bharatfed/service.py
@@ -1,0 +1,75 @@
+"""High-level BharatFed service orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .analytics import extract_transactions, forecast_cashflow, load_fiu_payload, summarize_transactions
+from .lending import LendingRepository
+
+
+class BharatFedService:
+    """Single facade used by the CLI/tests/API."""
+
+    def __init__(self, *, sample_data_path: str, database_path: str) -> None:
+        self.sample_data_path = sample_data_path
+        self.database_path = database_path
+        self.lending = LendingRepository(database_path)
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "sample_data_path": str(Path(self.sample_data_path)),
+            "database_path": str(Path(self.database_path)),
+        }
+
+    def analytics_overview(self) -> dict[str, Any]:
+        payload = load_fiu_payload(self.sample_data_path)
+        transactions = extract_transactions(payload)
+        summary = summarize_transactions(transactions)
+        summary["data_source"] = Path(self.sample_data_path).name
+        return summary
+
+    def analytics_forecast(self, days: int = 30) -> dict[str, Any]:
+        payload = load_fiu_payload(self.sample_data_path)
+        transactions = extract_transactions(payload)
+        forecast = forecast_cashflow(transactions, days=days)
+        forecast["data_source"] = Path(self.sample_data_path).name
+        return forecast
+
+    def list_profiles(self) -> list[dict[str, Any]]:
+        return self.lending.list_profiles()
+
+    def get_profile(self, user_id: str) -> dict[str, Any] | None:
+        return self.lending.get_profile(user_id)
+
+    def list_loan_requests(self, status: str | None = None) -> list[dict[str, Any]]:
+        return self.lending.list_loan_requests(status=status)
+
+    def list_loans(self) -> list[dict[str, Any]]:
+        return self.lending.list_loans()
+
+    def portfolio_summary(self) -> dict[str, Any]:
+        return self.lending.portfolio_summary()
+
+    def create_loan_request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        required_fields = {
+            "borrower_id",
+            "lender_id",
+            "loan_amount",
+            "interest_rate",
+            "loan_period_months",
+            "text",
+        }
+        missing = sorted(required_fields - payload.keys())
+        if missing:
+            raise ValueError(f"missing required fields: {', '.join(missing)}")
+        return self.lending.create_loan_request(
+            borrower_id=str(payload["borrower_id"]),
+            lender_id=str(payload["lender_id"]),
+            loan_amount=float(payload["loan_amount"]),
+            interest_rate=float(payload["interest_rate"]),
+            loan_period_months=int(payload["loan_period_months"]),
+            text=str(payload["text"]),
+        )

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,31 @@
+import unittest
+
+from bharatfed.analytics import extract_transactions, forecast_cashflow, load_fiu_payload, summarize_transactions
+
+
+class AnalyticsTests(unittest.TestCase):
+    def test_summary_contains_expected_ranges(self) -> None:
+        payload = load_fiu_payload("data_response_bharatfed99@finvu_1yr.txt")
+        transactions = extract_transactions(payload)
+        summary = summarize_transactions(transactions)
+
+        self.assertEqual(summary["transaction_count"], len(transactions))
+        self.assertEqual(summary["date_range"]["start"], "2019-07-20")
+        self.assertEqual(summary["date_range"]["end"], "2020-07-06")
+        self.assertGreater(summary["credits_total"], 0)
+        self.assertGreater(summary["debits_total"], 0)
+        self.assertGreaterEqual(summary["current_balance"], 0)
+        self.assertTrue(summary["top_expense_categories"])
+
+    def test_forecast_returns_sorted_projection(self) -> None:
+        payload = load_fiu_payload("data_response_bharatfed99@finvu_1yr.txt")
+        transactions = extract_transactions(payload)
+        forecast = forecast_cashflow(transactions, days=14)
+
+        dates = [entry["date"] for entry in forecast["forecast"]]
+        self.assertEqual(dates, sorted(dates))
+        self.assertGreaterEqual(forecast["projected_end_balance"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,55 @@
+import json
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+from bharatfed.api import create_server
+from bharatfed.service import BharatFedService
+
+
+class APITests(unittest.TestCase):
+    def test_http_endpoints_expose_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_copy = Path(temp_dir) / "bharat_fed.db"
+            database_copy.write_bytes(Path("bharat_fed.db").read_bytes())
+            service = BharatFedService(
+                sample_data_path="data_response_bharatfed99@finvu_1yr.txt",
+                database_path=str(database_copy),
+            )
+            server = create_server("127.0.0.1", 0, service)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            port = server.server_address[1]
+
+            try:
+                with urlopen(f"http://127.0.0.1:{port}/health") as response:
+                    health = json.loads(response.read().decode("utf-8"))
+                self.assertEqual(health["status"], "ok")
+
+                payload = {
+                    "borrower_id": "000001",
+                    "lender_id": "000000",
+                    "loan_amount": 15000,
+                    "interest_rate": 9.5,
+                    "loan_period_months": 4,
+                    "text": "Inventory restocking",
+                }
+                request = Request(
+                    f"http://127.0.0.1:{port}/loans/requests",
+                    data=json.dumps(payload).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urlopen(request) as response:
+                    created = json.loads(response.read().decode("utf-8"))
+                self.assertEqual(created["status"], "PENDING")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lending.py
+++ b/tests/test_lending.py
@@ -1,0 +1,56 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from bharatfed.lending import LendingRepository
+from bharatfed.service import BharatFedService
+
+
+def _copy_database(source: str, destination: Path) -> str:
+    destination.write_bytes(Path(source).read_bytes())
+    return str(destination)
+
+
+class LendingTests(unittest.TestCase):
+    def test_portfolio_summary_uses_existing_database(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = _copy_database("bharat_fed.db", Path(temp_dir) / "bharat_fed.db")
+            service = BharatFedService(
+                sample_data_path="data_response_bharatfed99@finvu_1yr.txt",
+                database_path=database_path,
+            )
+
+            summary = service.portfolio_summary()
+
+            self.assertGreaterEqual(summary["profiles"], 2)
+            self.assertGreaterEqual(summary["active_loans"], 1)
+            self.assertGreaterEqual(summary["loan_requests_total"], 1)
+
+    def test_create_loan_request_inserts_pending_record(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            database_path = _copy_database("bharat_fed.db", Path(temp_dir) / "bharat_fed.db")
+            repository = LendingRepository(database_path)
+
+            created = repository.create_loan_request(
+                borrower_id="000001",
+                lender_id="000000",
+                loan_amount=25000,
+                interest_rate=12.5,
+                loan_period_months=6,
+                text="Need working capital for my shop",
+            )
+
+            self.assertEqual(created["status"], "PENDING")
+
+            with sqlite3.connect(database_path) as connection:
+                row = connection.execute(
+                    "SELECT borrower_id, lender_id, loan_amount, req_status FROM loan_reqs WHERE loan_req_id = ?",
+                    (created["loan_req_id"],),
+                ).fetchone()
+
+            self.assertEqual(row, ("000001", "000000", 25000.0, "PENDING"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make the repository immediately usable as a backend by converting legacy scripts into a small dependency-light service layer and HTTP API. 
- Provide deterministic, explainable analytics and a safe interface for the existing SQLite-backed lending data so the project can be exercised in constrained environments.

### Description
- Add a new `bharatfed` package containing `analytics.py` (FIU payload parsing, normalized `Transaction` model, summaries and rule-based cashflow `forecast`), `lending.py` (SQLite `LendingRepository`, EMI helper, profile/loan/loan-request helpers), `service.py` (application facade), and `api.py` (minimal stdlib JSON HTTP API and `create_server`).
- Add `app.py` as a runnable entrypoint with CLI flags for `--sample-data` and `--database` to run the local server.
- Add unit tests in `tests/` covering analytics (`tests/test_analytics.py`), lending (`tests/test_lending.py`), and the HTTP API (`tests/test_api.py`).
- Update `README.md` to document the new backend, endpoints, how to run the server, and the test workflow.

### Testing
- Ran the test suite with `python -m unittest discover -s tests -v` and all tests passed (5 tests, OK). 
- Verified the CLI help with `python app.py --help` and exercised the service facade with the snippet that prints `service.analytics_overview()` and `service.portfolio_summary()` which returned expected values.
- Started the in-process HTTP server in tests and validated `/health` and `POST /loans/requests` behavior via `urllib` calls (covered by `tests/test_api.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7ce0e8288328984cd825464351d5)